### PR TITLE
Readd logic to `__wakeup()`

### DIFF
--- a/src/wp-includes/class-wp-block-bindings-registry.php
+++ b/src/wp-includes/class-wp-block-bindings-registry.php
@@ -285,7 +285,17 @@ final class WP_Block_Bindings_Registry {
 	 * @since 6.5.0
 	 */
 	public function __wakeup() {
-		$this->__unserialize( array() );
+		if ( ! $this->sources ) {
+			return;
+		}
+		if ( ! is_array( $this->sources ) ) {
+			throw new UnexpectedValueException();
+		}
+		foreach ( $this->sources as $value ) {
+			if ( ! $value instanceof WP_Block_Bindings_Source ) {
+				throw new UnexpectedValueException();
+			}
+		}
 	}
 
 	/**

--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -275,7 +275,18 @@ final class WP_Block_Patterns_Registry {
 	 * @since 6.4.0
 	 */
 	public function __wakeup() {
-		$this->__unserialize( array() );
+		if ( ! $this->registered_patterns ) {
+			return;
+		}
+		if ( ! is_array( $this->registered_patterns ) ) {
+			throw new UnexpectedValueException();
+		}
+		foreach ( $this->registered_patterns as $value ) {
+			if ( ! is_array( $value ) ) {
+				throw new UnexpectedValueException();
+			}
+		}
+		$this->registered_patterns_outside_init = array();
 	}
 
 	/**

--- a/src/wp-includes/class-wp-block-type-registry.php
+++ b/src/wp-includes/class-wp-block-type-registry.php
@@ -197,7 +197,17 @@ final class WP_Block_Type_Registry {
 	 * @since 6.4.0
 	 */
 	public function __wakeup() {
-		$this->__unserialize( array() );
+		if ( ! $this->registered_block_types ) {
+			return;
+		}
+		if ( ! is_array( $this->registered_block_types ) ) {
+			throw new UnexpectedValueException();
+		}
+		foreach ( $this->registered_block_types as $value ) {
+			if ( ! $value instanceof WP_Block_Type ) {
+				throw new UnexpectedValueException();
+			}
+		}
 	}
 
 	/**

--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -812,7 +812,18 @@ final class WP_Theme implements ArrayAccess {
 	 * @since 6.4.0
 	 */
 	public function __wakeup() {
-		$this->__unserialize( array() );
+		if ( $this->parent && ! $this->parent instanceof self ) {
+			throw new UnexpectedValueException();
+		}
+		if ( $this->headers && ! is_array( $this->headers ) ) {
+			throw new UnexpectedValueException();
+		}
+		foreach ( $this->headers as $value ) {
+			if ( ! is_string( $value ) ) {
+				throw new UnexpectedValueException();
+			}
+		}
+		$this->headers_sanitized = array();
 	}
 
 	/**


### PR DESCRIPTION
This readds the previous logic to the `__wakeup()` magic method.

When `__wakeup()` is called on PHP 7.2 & 7.3, an empty `array()` is currently passed to `__unserialize()`, which means the instance will always be unserialized into an empty object.

Trac ticket: Core-63962

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
